### PR TITLE
Read github READ_WRITE_TOKEN from vault.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
         token: ${{ secrets.VAULT_TOKEN }}
         secrets: |
           kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
+          kv/data/github  "READ_WRITE_TOKEN"    | READ_WRITE_TOKEN;
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/Depfile
+++ b/Depfile
@@ -15,10 +15,11 @@ go:
 bin:
   vault:
     url: "https://releases.hashicorp.com/vault/{{.Version}}/vault_{{.Version}}_{{.OS}}_{{.Arch}}.zip"
-    version: "1.8.1"
+    version: "1.8.12"
     zipPaths:
     - "./vault"
     sha:
-      linux-amd64: "bb411f2bbad79c2e4f0640f1d3d5ef50e2bda7d4f40875a56917c95ff783c2db"
-      darwin-amd64: "f87221e4f56b3da41f0a029bf2b48896ec3be84dd7075bdb9466def1e056f809"
-      darwin-arm64: "571985c34990a2a7b913cee8c50be42b34c8d8cb751a2aed2c80121ad4b4e44b"
+      linux-amd64: "88c280945db62b118435ec1bf0086a719f6b6551cba052e5f8d1e25a80884bca"
+      linux-arm64: "e57e719e1eec9bce9057751e2583907210d3ac99c0a01897479506fbb2af828d"
+      darwin-amd64: "b398481bf33ebf9563cf69d7639014f0d652a2d5e26c0a9a424e2a39bb853354"
+      darwin-arm64: "18096cfdacba56a806f1b4b47ea20b3c03f062b5162c53a2b61b0b591d00aa65"


### PR DESCRIPTION
READ_WRITE_TOKEN is used to dispatch a workflow in aserto-dev/ts-authorizer but was never actually read from vault.