### PR TITLE
updated authorizer-config.json to include hosted authorizer URL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,8 +85,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    if: true == false #TODO: figure out how we release this.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Read Configuration
         uses: hashicorp/vault-action@v2.4.1
@@ -97,7 +96,6 @@ jobs:
           secrets: |
             kv/data/readme  "README_VERSION_API_KEY"       | README_VERSION_API_KEY;
             kv/data/readme  "AUTHORIZER_API_DEFINITION_ID" | AUTHORIZER_API_DEFINITION_ID;
-            kv/data/readme  "TENANT_API_DEFINITION_ID"     | TENANT_API_DEFINITION_ID;
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -128,9 +126,6 @@ jobs:
 
           echo "Publish authorizer API spec"
           npx rdme openapi ./publish/authorizer/openapi.json --key ${{ steps.vault.outputs.README_VERSION_API_KEY }} --id ${{ steps.vault.outputs.AUTHORIZER_API_DEFINITION_ID }}
-
-          echo "Publish tenant API spec"
-          npx rdme openapi ./publish/tenant/openapi.json --key ${{ steps.vault.outputs.README_VERSION_API_KEY }} --id ${{ steps.vault.outputs.TENANT_API_DEFINITION_ID }}
 
           echo "Update API spec version"
           npx rdme versions:update --version=$LATEST_READMEIO_VERSION --key ${{ steps.vault.outputs.README_VERSION_API_KEY }} --isPublic true --main true --beta false <<< ${{ env.RELEASE_VERSION }}

--- a/config/authorizer-config.json
+++ b/config/authorizer-config.json
@@ -20,6 +20,10 @@
     },
     "servers": [
         {
+            "description": "Hosted authorizer service",
+            "url": "https://authorizer.prod.aserto.com"
+        },
+        {
             "description": "Local authorizer service using Topaz",
             "url": "https://localhost:{port}",
             "variables": {

--- a/publish/authorizer/openapi.json
+++ b/publish/authorizer/openapi.json
@@ -761,6 +761,10 @@
   ],
   "servers": [
     {
+      "description": "Hosted authorizer service",
+      "url": "https://authorizer.prod.aserto.com"
+    },
+    {
       "description": "Local authorizer service using Topaz",
       "url": "https://localhost:{port}",
       "variables": {

--- a/publish/authorizer/openapi.yaml
+++ b/publish/authorizer/openapi.yaml
@@ -2187,6 +2187,9 @@ security:
   - AuthorizerAPIKey: []
 servers:
   - extensionprops: {}
+    url: https://authorizer.prod.aserto.com
+    description: Hosted authorizer service
+  - extensionprops: {}
     url: https://localhost:{port}
     description: Local authorizer service using Topaz
     variables:


### PR DESCRIPTION
This PR adds the hosted authorizer to the list of servers in authorizer-config.json.

It also includes the resulting openapi.json / openapi.yaml files generated by `mage generate`.