### PR TITLE
CI checks out the repo using a GH app token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -24,63 +25,71 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Read Configuration
-      uses: hashicorp/vault-action@v3
-      id: vault
-      with:
-        url: ${{ env.VAULT_ADDR }}
-        token: ${{ secrets.VAULT_TOKEN }}
-        secrets: |
-          kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
-          kv/data/github  "READ_WRITE_TOKEN"    | READ_WRITE_TOKEN;
+      -
+        name: Read Configuration
+        uses: hashicorp/vault-action@v3
+        id: vault
+        with:
+          url: ${{ env.VAULT_ADDR }}
+          token: ${{ secrets.VAULT_TOKEN }}
+          secrets: |
+            kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
+            kv/data/github  "READ_WRITE_TOKEN"    | READ_WRITE_TOKEN;
+      -
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_KEY }}
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      -
+        name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      -
+        name: Install dependencies
+        run: |
+            mkdir -p $HOME/.ssh
+            umask 0077 && echo -e "${SSH_PRIVATE_KEY}" > $HOME/.ssh/id_rsa
+            ssh-keyscan github.com >> $HOME/.ssh/known_hosts
 
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+            git config --global url."git@github.com:".insteadOf https://github.com/
+            git config --global user.email "github-bot@aserto.com"
+            git config --global user.name "Aserto Bot"
 
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
+            eval `ssh-agent`
+            ssh-add $HOME/.ssh/id_rsa
 
-    - name: Install dependencies
-      run: |
-          mkdir -p $HOME/.ssh
-          umask 0077 && echo -e "${SSH_PRIVATE_KEY}" > $HOME/.ssh/id_rsa
-          ssh-keyscan github.com >> $HOME/.ssh/known_hosts
-
-          git config --global url."git@github.com:".insteadOf https://github.com/
-          git config --global user.email "github-bot@aserto.com"
-          git config --global user.name "Aserto Bot"
-
-          eval `ssh-agent`
-          ssh-add $HOME/.ssh/id_rsa
-
-          go run mage.go deps
-
-    - name: Clean generated code
-      run: go run mage.go clean
-
-    - name: Generate
-      run: go run mage.go generate
-
-    - name: Commit changes
-      id: commit_changes
-      if: github.event_name == 'workflow_dispatch'
-      uses: EndBug/add-and-commit@v9
-      with:
-        default_author: github_actions
-
-    - name: Dispatch to aserto-dev/ts-authorizer if a change was committed
-      if: steps.commit_changes.outputs.committed && github.event_name == 'workflow_dispatch'
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-        inputs: '{"OPENAPI_SHA": "${{ steps.commit_changes.outputs.commit_sha }}", "PROTO_REF": "${{ github.event.inputs.proto_ref }}"}'
-        ref: main
-        repo: aserto-dev/ts-authorizer
-        token: ${{ steps.vault.outputs.READ_WRITE_TOKEN }}
-        workflow: generate
+            go run mage.go deps
+      -
+        name: Clean generated code
+        run: go run mage.go clean
+      -
+        name: Generate
+        run: go run mage.go generate
+      -
+        name: Commit changes
+        id: commit_changes
+        if: github.event_name == 'workflow_dispatch'
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+      -
+        name: Dispatch to aserto-dev/ts-authorizer if a change was committed
+        if: steps.commit_changes.outputs.committed && github.event_name == 'workflow_dispatch'
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          inputs: '{"OPENAPI_SHA": "${{ steps.commit_changes.outputs.commit_sha }}", "PROTO_REF": "${{ github.event.inputs.proto_ref }}"}'
+          ref: main
+          repo: aserto-dev/ts-authorizer
+          token: ${{ steps.vault.outputs.READ_WRITE_TOKEN }}
+          workflow: generate
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The app is allowed to bypass branch protection rules in the repo. This setup ensures that branch protection is enforced for human contributors, but the automated workflow can generate code and commit it to main.